### PR TITLE
Hex colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,61 @@
-Exploratory package (read: API very subject to change & breakage) for playing with different approaches to modeling and working with Color.
+Work with Colors in Elm.
 
-I'm interested in exploring generative accessible palettes, in addition to playing with validating accessibility of existing palettes.
+This package makes working with RGB, HSL, and Hex colors easy, convenient, and safe.
+Easily convert from one color system to another, blend and transform colors, and generate
+beautiful palettes programmatically. Use named colors from common web color palettes, like X11.
+
+Currently, `palette` does not provide first-class alpha channel support (transparency).
+
+Long term, I'm interested in exploring generating accessible palettes and validating
+the accessibility of existing palettes. Check out the `Color.Contrast` for more on accessibility.
+
+Issues, bugs, and enhancement suggestions very welcome on the github repo.
 
 ## Getting started
 
-Suppose you want to build a palette.
+You can view named colors in the `Palette` namespace, but sometimes you'll want to make your own
+custom or user defined colors.
 
-You might be thinking in terms of the color
-wheel, and in terms of colors relationship to each other on that wheel.
-Suppose we want to find 2 colors that are evenly spaced from each other on the color wheel.
+The library currently supports creating `Color`s from RGB values, HSL values, and hex values.
+
+```
+import Color exposing (Color)
+
+
+myOrangeyRed : Color
+myOrangeyRed =
+    Color.fromRGB ( 255, 80, 0 )
+
+
+myTurquoiseIsh : Color
+myTurquoiseIsh =
+    Color.fromHSL (127, 50, 50)
+
+
+myHex : Result String Color
+myHex =
+    Color.fromHexString "#ff9800"
+
+```
+
+### Generating a palette
+
+Suppose you want to use a three-color palette, and you know you want one of the colors to be red.
+Maybe you want the palette to be comprised of evenly-spaced colors on the color wheel.
 
 ```
 import Color exposing (Color)
 import Color.Generator
+import Palette.X11 exposing (red)
 
 myPalette : (Color, Color, Color)
 myPalette =
     let
-        red =
-            Color.fromHSL 0 100 50
-
-        (color1, color2) =
-            Color.triadic red
+        (color2, color3) =
+            triadic red
     in
-        (red, color1, color2)
+    (red, color2, color3))
+
 ```
 
 Or maybe we want a monochromatic color scheme -- the various tints and lightnesses
@@ -32,13 +64,12 @@ available from a starting hue.
 ```
 import Color exposing (Color)
 import Color.Generator
+import Palette.X11 exposing (red)
+
 
 myPalette : List Color
 myPalette =
     let
-        red =
-            Color.fromRGB ( 255, 0, 0 )
-
         stepSize =
             -- how many degrees of lightness apart each step should be
             10
@@ -47,8 +78,18 @@ myPalette =
         Color.Generator.monochromatic stepSize red
 ```
 
+### Mixing colors together
 
-## Developing
+If you've used Photoshop, you may be familiar with color blending with functions
+like `multiply`. If not, I recommend taking a lot at the examples & playing until
+you get a feel for what the functions do.
+
+### Working with contrast
+
+Use `Color.Contrast` functions to verify that your font size, boldness, and color
+meet accessibility standards.
+
+## Developing & Contributing
 
 ### Examples
 
@@ -66,9 +107,3 @@ I couldn't get the tests working on travis ci properly :( But there are tests!
 npm install
 npm test
 ```
-
-### Maybe TODOs
-
-- What other common web palettes would be helpful to have available? are there others?
-- Transparency -- rgba and hsla. worth adding?
-- API -- other color formats & conversions?

--- a/examples/src/ColorPicker.elm
+++ b/examples/src/ColorPicker.elm
@@ -24,8 +24,7 @@ view model =
     Html.label []
         [ Html.input
             [ Html.Attributes.type_ "color"
-            , Color.toRGB model.selectedColor
-                |> toHexString
+            , Color.toHexString model.selectedColor
                 |> Html.Attributes.value
             , Html.Events.onInput SetHexColor
             ]
@@ -48,59 +47,3 @@ update msg { selectedColor } =
                         |> Result.withDefault selectedColor
             in
             ( Model newColor, Just newColor )
-
-
-
--- HEX conversions (to be pulled into the main Color module eventually)
-
-
-getHexSymbol : Int -> String
-getHexSymbol m =
-    let
-        hexValues =
-            Dict.fromList
-                [ ( 0, "0" )
-                , ( 1, "1" )
-                , ( 2, "2" )
-                , ( 3, "3" )
-                , ( 4, "4" )
-                , ( 5, "5" )
-                , ( 6, "6" )
-                , ( 7, "7" )
-                , ( 8, "8" )
-                , ( 9, "9" )
-                , ( 10, "A" )
-                , ( 11, "B" )
-                , ( 12, "C" )
-                , ( 13, "D" )
-                , ( 14, "E" )
-                , ( 15, "F" )
-                ]
-    in
-    Dict.get m hexValues
-        |> Maybe.withDefault "0"
-
-
-decToHex : Float -> String
-decToHex c =
-    let
-        nextValue ( dec, hex ) =
-            if dec == 0 then
-                hex
-
-            else
-                nextValue
-                    ( dec // 16
-                    , getHexSymbol (remainderBy 16 dec) ++ hex
-                    )
-    in
-    if c == 0 then
-        "00"
-
-    else
-        nextValue ( round c, "" )
-
-
-toHexString : ( Float, Float, Float ) -> String
-toHexString ( r, g, b ) =
-    "#" ++ decToHex r ++ decToHex g ++ decToHex b

--- a/examples/src/ColorPicker.elm
+++ b/examples/src/ColorPicker.elm
@@ -44,7 +44,7 @@ update msg { selectedColor } =
         SetHexColor colorString ->
             let
                 newColor =
-                    fromHexString colorString
+                    Color.fromHexString colorString
                         |> Result.withDefault selectedColor
             in
             ( Model newColor, Just newColor )
@@ -104,54 +104,3 @@ decToHex c =
 toHexString : ( Float, Float, Float ) -> String
 toHexString ( r, g, b ) =
     "#" ++ decToHex r ++ decToHex g ++ decToHex b
-
-
-fromHexString : String -> Result String Color
-fromHexString colorString =
-    let
-        colorList =
-            String.dropLeft 1 colorString
-                |> String.toList
-                |> List.map fromHexSymbol
-    in
-    case colorList of
-        r1 :: r0 :: g1 :: g0 :: b1 :: b0 :: [] ->
-            ( r1 * 16 + r0 |> toFloat
-            , g1 * 16 + g0 |> toFloat
-            , b1 * 16 + b0 |> toFloat
-            )
-                |> Color.fromRGB
-                |> Ok
-
-        r :: g :: b :: [] ->
-            Err "fromHexString does not support 3-character hex strings."
-
-        _ ->
-            Err ("fromHexString could not convert " ++ colorString ++ " to a Color.")
-
-
-fromHexSymbol : Char -> Int
-fromHexSymbol m =
-    let
-        decValues =
-            Dict.fromList
-                [ ( '0', 0 )
-                , ( '1', 1 )
-                , ( '2', 2 )
-                , ( '3', 3 )
-                , ( '4', 4 )
-                , ( '5', 5 )
-                , ( '6', 6 )
-                , ( '7', 7 )
-                , ( '8', 8 )
-                , ( '9', 9 )
-                , ( 'A', 10 )
-                , ( 'B', 11 )
-                , ( 'C', 12 )
-                , ( 'D', 13 )
-                , ( 'E', 14 )
-                , ( 'F', 15 )
-                ]
-    in
-    Dict.get (Char.toUpper m) decValues
-        |> Maybe.withDefault 0

--- a/examples/src/ColorPicker.elm
+++ b/examples/src/ColorPicker.elm
@@ -1,12 +1,9 @@
 module ColorPicker exposing (Model, Msg, init, update, view)
 
 import Color exposing (Color)
-import Color.Generator exposing (adjustLightness, adjustSaturation, rotate)
-import Dict
 import Html exposing (Html)
 import Html.Attributes exposing (attribute, id, style)
 import Html.Events
-import Json.Decode
 
 
 type alias Model =

--- a/src/Color.elm
+++ b/src/Color.elm
@@ -224,8 +224,8 @@ toRGBString color =
 
 {-| Build a new color from a hex string. Supports lowercase or uppercase strings.
 
-    myColorResult =
-        Color.fromHexString "#FFDD00"
+    (Color.fromHexString "#FFDD00" == Color.fromHexString "#FD0")
+        && (Color.fromHexString "#FFDD00" == Color.fromHexString "#ffdd00")
 
 -}
 fromHexString : String -> Result String Color
@@ -246,7 +246,12 @@ fromHexString colorString =
                 |> Ok
 
         r :: g :: b :: [] ->
-            Err "fromHexString does not support 3-character hex strings."
+            ( r * 16 + r |> toFloat
+            , g * 16 + g |> toFloat
+            , b * 16 + b |> toFloat
+            )
+                |> fromRGB
+                |> Ok
 
         _ ->
             Err ("fromHexString could not convert " ++ colorString ++ " to a Color.")
@@ -265,6 +270,12 @@ fromHexString colorString =
             , value (toHexString red)
             ]
             []
+
+Note: this function will always return a string in the form "#RRGGBB". It will
+not return shortened values (e.g., "#RGB").
+
+If you want or need this functionality, please make an issue for it on the
+github repo for this library.
 
 -}
 toHexString : Color -> String

--- a/src/Color.elm
+++ b/src/Color.elm
@@ -265,7 +265,11 @@ fromHexString colorString =
 -}
 toHexString : Color -> String
 toHexString color =
-    "#TODO"
+    let
+        ( r, g, b ) =
+            toRGB color
+    in
+    "#" ++ decToHex r ++ decToHex g ++ decToHex b
 
 
 {-| Luminance calculation adopted from <https://www.w3.org/TR/WCAG20-TECHS/G17.html>
@@ -414,6 +418,26 @@ convertHSLToRGB (HSLValue hue360 saturationPercent lightnessPercent) =
 {- Hex/Dec lookup tables -}
 
 
+decToHex : Float -> String
+decToHex c =
+    let
+        nextValue ( dec, hex ) =
+            if dec == 0 then
+                hex
+
+            else
+                nextValue
+                    ( dec // 16
+                    , getHexSymbol (remainderBy 16 dec) ++ hex
+                    )
+    in
+    if c == 0 then
+        "00"
+
+    else
+        nextValue ( round c, "" )
+
+
 fromHexSymbol : Char -> Int
 fromHexSymbol m =
     let
@@ -439,3 +463,30 @@ fromHexSymbol m =
     in
     Dict.get (Char.toUpper m) decValues
         |> Maybe.withDefault 0
+
+
+getHexSymbol : Int -> String
+getHexSymbol m =
+    let
+        hexValues =
+            Dict.fromList
+                [ ( 0, "0" )
+                , ( 1, "1" )
+                , ( 2, "2" )
+                , ( 3, "3" )
+                , ( 4, "4" )
+                , ( 5, "5" )
+                , ( 6, "6" )
+                , ( 7, "7" )
+                , ( 8, "8" )
+                , ( 9, "9" )
+                , ( 10, "A" )
+                , ( 11, "B" )
+                , ( 12, "C" )
+                , ( 13, "D" )
+                , ( 14, "E" )
+                , ( 15, "F" )
+                ]
+    in
+    Dict.get m hexValues
+        |> Maybe.withDefault "0"

--- a/src/Color.elm
+++ b/src/Color.elm
@@ -244,12 +244,15 @@ fromHexString colorString =
 
     import Color exposing (toHexString)
     import Html exposing (p, text)
-    import Html.Attributes exposing (style)
+    import Html.Attributes exposing (type_, value)
     import Palette.X11 exposing (red)
 
     view =
-        p [ style "color" (toHexString red) ]
-            [ text "Wow! This sure looks red!" ]
+        Html.input
+            [ type_ "color"
+            , value (toHexString red)
+            ]
+            []
 
 -}
 toHexString : Color -> String

--- a/src/Color.elm
+++ b/src/Color.elm
@@ -2,6 +2,7 @@ module Color exposing
     ( Color
     , fromHSL, toHSL, toHSLString
     , fromRGB, toRGB, toRGBString
+    , fromHexString, toHexString
     , luminance
     )
 
@@ -61,6 +62,15 @@ color space. Printing (CMYK color space) is also subtractive.
 @docs fromRGB, toRGB, toRGBString
 
 
+### Hex values
+
+Hexadecimal colors actually use the same color space as RGB colors. The difference
+between the two systems is in the base: RGB colors are base 10 and hex colors are base 16.
+Hex colors are also additive and can also be thought of as a piecewise function.
+
+@docs fromHexString, toHexString
+
+
 ## Color properties
 
 @docs luminance
@@ -74,6 +84,7 @@ type
     -- TODO: other models! conversions! as necessary.
     = HSL HSLValue
     | RGB RGBValue
+    | Hex HexValue
 
 
 {-| Internal representation of HSL used to enforce type safety.
@@ -86,6 +97,12 @@ type HSLValue
 -}
 type RGBValue
     = RGBValue Float Float Float
+
+
+{-| Internal representation of RGB used to enforce type safety.
+-}
+type alias HexValue =
+    { r1 : Char, r0 : Char, g1 : Char, g0 : Char, b1 : Char, b0 : Char }
 
 
 {-| Build a new color based on HSL values.
@@ -129,6 +146,9 @@ toHSL color =
         RGB rgbValues ->
             convertRGBToHSL rgbValues
                 |> toHSL
+
+        Hex { r1, r0, g1, g0, b1, b0 } ->
+            ( 0, 0, 0 )
 
 
 {-| Get the HSL representation of a color as a `String`.
@@ -184,6 +204,9 @@ toRGB color =
         RGB (RGBValue r g b) ->
             ( r, g, b )
 
+        Hex { r1, r0, g1, g0, b1, b0 } ->
+            ( 0, 0, 0 )
+
         HSL hslValues ->
             convertHSLToRGB hslValues
                 |> toRGB
@@ -208,6 +231,30 @@ toRGBString color =
             toRGB color
     in
     "rgb(" ++ String.fromFloat r ++ "," ++ String.fromFloat g ++ "," ++ String.fromFloat b ++ ")"
+
+
+{-| Build a new color from a hex string.
+-}
+fromHexString : String -> Color
+fromHexString colorString =
+    Hex (HexValue '0' '0' '0' '0' '0' '0')
+
+
+{-| Get the Hex representation of a color as a `String`.
+
+    import Color exposing (toHexString)
+    import Html exposing (p, text)
+    import Html.Attributes exposing (style)
+    import Palette.X11 exposing (red)
+
+    view =
+        p [ style "color" (toHexString red) ]
+            [ text "Wow! This sure looks red!" ]
+
+-}
+toHexString : Color -> String
+toHexString color =
+    "#TODO"
 
 
 {-| Luminance calculation adopted from <https://www.w3.org/TR/WCAG20-TECHS/G17.html>

--- a/src/Color.elm
+++ b/src/Color.elm
@@ -435,11 +435,7 @@ decToHex c =
                     , getHexSymbol (remainderBy 16 dec) ++ hex
                     )
     in
-    if c == 0 then
-        "00"
-
-    else
-        nextValue ( round c, "" )
+    String.padLeft 2 '0' (nextValue ( round c, "" ))
 
 
 fromHexSymbol : Char -> Maybe Int

--- a/src/Color.elm
+++ b/src/Color.elm
@@ -63,7 +63,6 @@ color space. Printing (CMYK color space) is also subtractive.
 
 Hexadecimal colors actually use the same color space as RGB colors. The difference
 between the two systems is in the base: RGB colors are base 10 and hex colors are base 16.
-Hex colors are also additive and can also be thought of as a piecewise function.
 
 You will need to use hex colors if you're working with an
 [HTML input of type color](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color).

--- a/src/Color.elm
+++ b/src/Color.elm
@@ -222,7 +222,11 @@ toRGBString color =
     "rgb(" ++ String.fromFloat r ++ "," ++ String.fromFloat g ++ "," ++ String.fromFloat b ++ ")"
 
 
-{-| Build a new color from a hex string.
+{-| Build a new color from a hex string. Supports lowercase or uppercase strings.
+
+    myColorResult =
+        Color.fromHexString "#FFDD00"
+
 -}
 fromHexString : String -> Result String Color
 fromHexString colorString =
@@ -230,7 +234,7 @@ fromHexString colorString =
         colorList =
             String.dropLeft 1 colorString
                 |> String.toList
-                |> List.map fromHexSymbol
+                |> List.filterMap fromHexSymbol
     in
     case colorList of
         r1 :: r0 :: g1 :: g0 :: b1 :: b0 :: [] ->
@@ -438,7 +442,7 @@ decToHex c =
         nextValue ( round c, "" )
 
 
-fromHexSymbol : Char -> Int
+fromHexSymbol : Char -> Maybe Int
 fromHexSymbol m =
     let
         decValues =
@@ -462,7 +466,6 @@ fromHexSymbol m =
                 ]
     in
     Dict.get (Char.toUpper m) decValues
-        |> Maybe.withDefault 0
 
 
 getHexSymbol : Int -> String

--- a/src/Color.elm
+++ b/src/Color.elm
@@ -11,10 +11,7 @@ module Color exposing
 @docs Color
 
 
-## Working with `Color`s
-
-
-### HSL values
+## HSL values
 
 HSL is short for hue, saturation, and lightness (or luminosity, or random other
 L words depending on who you ask. Think "brightness", and you'll be on the right track).
@@ -62,11 +59,14 @@ color space. Printing (CMYK color space) is also subtractive.
 @docs fromRGB, toRGB, toRGBString
 
 
-### Hex values
+## Hex values
 
 Hexadecimal colors actually use the same color space as RGB colors. The difference
 between the two systems is in the base: RGB colors are base 10 and hex colors are base 16.
 Hex colors are also additive and can also be thought of as a piecewise function.
+
+You will need to use hex colors if you're working with an
+[HTML input of type color](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color).
 
 @docs fromHexString, toHexString
 

--- a/tests/ColorSpec.elm
+++ b/tests/ColorSpec.elm
@@ -26,7 +26,7 @@ colorSpec =
             , test "from lowercase Hex to Hex" <|
                 \_ ->
                     Color.fromHexString "#d3e700"
-                        |> Result.map (Color.toHexString >> Expect.equal "#FFD700")
+                        |> Result.map (Color.toHexString >> Expect.equal "#D3E700")
                         |> Result.withDefault (Expect.fail "Could not parse color string")
             , test "from Hex to Hex" <|
                 \_ ->

--- a/tests/ColorSpec.elm
+++ b/tests/ColorSpec.elm
@@ -41,6 +41,19 @@ colorSpec =
                                 |> Result.map (Color.toHexString >> Expect.equal hex)
                                 |> Result.withDefault (Expect.fail "Could not parse color string")
 
+                        else if String.length hex == 4 then
+                            let
+                                fullLengthHexString =
+                                    String.toList hex
+                                        |> List.concatMap (\v -> [ v, v ])
+                                        |> String.fromList
+                                        |> String.dropLeft 1
+                                        |> Debug.log "fullLengthHexString"
+                            in
+                            Color.fromHexString hex
+                                |> Result.map (Color.toHexString >> Expect.equal fullLengthHexString)
+                                |> Result.withDefault (Expect.fail "Could not parse color string")
+
                         else
                             Color.fromHexString hex
                                 |> Expect.err

--- a/tests/ColorSpec.elm
+++ b/tests/ColorSpec.elm
@@ -22,18 +22,18 @@ colorSpec =
             , test "from Hex with bad values" <|
                 \_ ->
                     Color.fromHexString "#FFDG00"
-                        |> Color.toHexString
-                        |> Expect.equal "#FFDG00"
+                        |> Result.map (Color.toHexString >> Expect.equal "#FFDG00")
+                        |> Result.withDefault (Expect.fail "Could not parse color string")
             , test "from lowercase Hex to Hex" <|
                 \_ ->
                     Color.fromHexString "#d3e700"
-                        |> Color.toHexString
-                        |> Expect.equal "#FFD700"
+                        |> Result.map (Color.toHexString >> Expect.equal "#FFD700")
+                        |> Result.withDefault (Expect.fail "Could not parse color string")
             , test "from Hex to Hex" <|
                 \_ ->
                     Color.fromHexString "#FFD700"
-                        |> Color.toHexString
-                        |> Expect.equal "#FFD700"
+                        |> Result.map (Color.toHexString >> Expect.equal "#FFD700")
+                        |> Result.withDefault (Expect.fail "Could not parse color string")
             ]
         , describe "to a String"
             [ test "toRGBString" <|

--- a/tests/ColorSpec.elm
+++ b/tests/ColorSpec.elm
@@ -45,6 +45,11 @@ colorSpec =
                     Color.fromHSL ( 15, -13, 300 )
                         |> Color.toHSLString
                         |> Expect.equal "hsl(15,0%,100%)"
+            , test "toHexString" <|
+                \_ ->
+                    Color.fromRGB ( -10, 123, 300 )
+                        |> Color.toHexString
+                        |> Expect.equal "#007BFF"
             ]
         , describe "between color models"
             [ test "from rgb black to hsl black" <|

--- a/tests/ColorSpec.elm
+++ b/tests/ColorSpec.elm
@@ -22,8 +22,7 @@ colorSpec =
             , test "from Hex with bad values" <|
                 \_ ->
                     Color.fromHexString "#FFDG00"
-                        |> Result.map (Color.toHexString >> Expect.equal "#FFDG00")
-                        |> Result.withDefault (Expect.fail "Could not parse color string")
+                        |> Expect.err
             , test "from lowercase Hex to Hex" <|
                 \_ ->
                     Color.fromHexString "#d3e700"

--- a/tests/ColorSpec.elm
+++ b/tests/ColorSpec.elm
@@ -19,6 +19,21 @@ colorSpec =
                 \_ ->
                     Color.fromHSL ( -10, 123, -10 )
                         |> expectHSLValues ( 350, 100, 0 )
+            , test "from Hex with bad values" <|
+                \_ ->
+                    Color.fromHexString "#FFDG00"
+                        |> Color.toHexString
+                        |> Expect.equal "#FFDG00"
+            , test "from lowercase Hex to Hex" <|
+                \_ ->
+                    Color.fromHexString "#d3e700"
+                        |> Color.toHexString
+                        |> Expect.equal "#FFD700"
+            , test "from Hex to Hex" <|
+                \_ ->
+                    Color.fromHexString "#FFD700"
+                        |> Color.toHexString
+                        |> Expect.equal "#FFD700"
             ]
         , describe "to a String"
             [ test "toRGBString" <|


### PR DESCRIPTION
Fixes https://github.com/tesk9/palette/issues/3

Adds:
```
fromHexString : String.String -> Result.Result String.String Color.Color
toHexString : Color.Color -> String.String
```

Makes some minor documentation and example improvements.